### PR TITLE
object_formatting rule

### DIFF
--- a/ast.js
+++ b/ast.js
@@ -401,11 +401,12 @@ function end(t) {
 }
 
 function object(t) {
-    if (t.length === 3) return { node: 'object', properties: [] }
+    if (t.length === 3) return { node: 'object', properties: [], tokens: xtok(flat(t).filter(_=>_)) }
     
     return {
         node: 'object',
-        properties: t[2].map(e => e[0]).concat([t[3]])
+        properties: t[2].map(e => e[0]).concat([t[3]]),
+        tokens: xtok(flat(t).filter(_=>_))
     }
 }
 function array(t) {
@@ -420,7 +421,8 @@ function propdef(t) {
     return {
         node: 'property',
         name: t[0].name,
-        value: t[4]
+        value: t[4],
+        tokens: xtok(flat(t).filter(_=>_))
     }
 }
 

--- a/cli.js
+++ b/cli.js
@@ -24,8 +24,7 @@ const lint = require('./brslint.js'),
 
 main()
 
-function main()
-{
+function main() {
     if (args.debug) {
         console.log(args)
     }
@@ -34,21 +33,21 @@ function main()
     let totalErrors = 0
     let allFunctions = []
 
-    const config = (args._[0])?
+    const config = (args._[0]) ?
         defaultConfig(args) :
         readconfig(args)
 
-    var files = readdir(config, '.brs', args.recursive)
+    let files = readdir(config, '.brs', args.recursive)
 
     if (files.length === 0) {
         console.log(color.yellow('Warning') + ": Couldn't find any BrightScript files to lint")
         process.exit(0)
     }
 
-    files.forEach(function (file) {
-        var input = fs.readFileSync(file, 'utf8')
-        var result = lint.parse(input, {preprocessor: args.preprocessor, debug: args.debug, ast: args.ast})
-        var name = pth.basename(file)
+    files.forEach(file => {
+        const input = fs.readFileSync(file, 'utf8')
+        const result = lint.parse(input, { preprocessor: args.preprocessor, debug: args.debug, ast: args.ast })
+        const name = pth.basename(file)
 
         if (args.message !== 'silent') {
             if (args.message !== 'errors' || result.errors.length > 0) {
@@ -61,11 +60,11 @@ function main()
 
         if (result.ast) {
             if (!args.p) {
-                const globalFnNames = result.ast.functions.map(f => f.name)
-                result.ast.functions.forEach(function (f) {
-                    f["file"] = file
-                    allFunctions.push(f)
-                    showWarnings(lint.style(f, globalFnNames))
+                const globalFnNames = result.ast.functions.map(func => func.name)
+                result.ast.functions.forEach(func => {
+                    func.file = file
+                    allFunctions.push(func)
+                    showWarnings(lint.style(func, globalFnNames))
                 })
                 
                 const rules = require('./rules')(config.rules, parseInt(args.warning))
@@ -92,17 +91,14 @@ function main()
             console.log('\nFinished with ' + totalErrors + color.redBright(' errors') + ' in ' + files.length + ' files')
         }
         process.exit(1)
-    }
-    else {
-        if (args.message !== 'silent') {
-            console.log("\nProcessed %d files, %d functions in %dms  =^..^=\n", files.length, allFunctions.length, processingTime)
-        }
+    } else if (args.message !== 'silent') {
+        console.log("\nProcessed %d files, %d functions in %dms  =^..^=\n", files.length, allFunctions.length, processingTime)
     }
 }
 
 
 function showErrors(errors, file) {
-    errors.forEach( function (error) {
+    errors.forEach(error => {
         console.log(color.redBright('  Error: ') + error + (args.format == 'robot' ? ' ' + file : ''))
     })
 }
@@ -160,8 +156,8 @@ function readdir(config, ext, recursive) {
 }
 
 function pathSort(a, b) {
-    var ad = a.split(pth.sep).length
-    var bd = b.split(pth.sep).length
+    const ad = a.split(pth.sep).length
+    const bd = b.split(pth.sep).length
     if (ad > bd)
         return 1
     else if (ad < bd)
@@ -202,7 +198,7 @@ function defaultConfig(args) {
             include: [args._[0] || '.'],
             exclude: []
         },
-        recursive: args.recursive || true,
+        recursive: args.recursive || true
     }
 
     return config

--- a/rules.js
+++ b/rules.js
@@ -195,7 +195,7 @@ class object_formatting extends rule(4) {
         this.spaces_before_colon = 0
         this.trailing_commas = 'no' // 'no', 'required'
         this.maxOneLine = 4
-        this.key_in_quotes = 'consistent' // 'allways', 'consistent', 'any'
+        this.key_in_quotes = 'consistent' // 'required', 'consistent'
     }
 
     check(node) {
@@ -250,7 +250,7 @@ class object_formatting extends rule(4) {
         for (const property of node.properties) {
             const keyInQuotes = /^".*"$/.test(property.name)
             if (keyInQuotes) quotedKeys += 1
-            if (this.key_in_quotes == 'allways' && !keyInQuotes) {
+            if (this.key_in_quotes == 'required' && !keyInQuotes) {
                 warnings.push(this.warning(property.value.token, 'key must be in quotes'))
             }
 

--- a/rules.js
+++ b/rules.js
@@ -194,7 +194,7 @@ class object_formatting extends rule(4) {
         this.spaces_after_colon = 1
         this.spaces_before_colon = 0
         this.trailing_commas = 'no' // 'no', 'required'
-        this.maxOneLine = 4
+        this.max_properties = 4
         this.key_in_quotes = 'consistent' // 'required', 'consistent'
     }
 
@@ -208,7 +208,7 @@ class object_formatting extends rule(4) {
         }
         const spaceCount = (token) => {
             if (token.type != 'ws') return 0
-            return token.value.length
+            return (token.value.match(/ /g) || []).length
         }
 
         const multiline = node.tokens.findIndex(item => newlineCount(item) > 0) > 0
@@ -232,19 +232,19 @@ class object_formatting extends rule(4) {
         }
 
         if (multiline) {
-            let zip = node.tokens
+            let pairs = node.tokens
                 .map((e, i) => [e, node.tokens[i + 1]])
                 .filter(e => e[0].value == ',')
 
-            for (const item of zip) {
+            for (const item of pairs) {
                 if (item[1].type == 'ws') {
                     warnings.push(this.warning(item[0], 'one property per line'))
                 } else if (this.trailing_commas == 'no') {
                     warnings.push(this.warning(item[0], 'no trailing commas in object literals'))
                 }
             }
-        } else if (this.maxOneLine < node.properties.length) {
-            warnings.push(this.warning(node.tokens, `object literals with more than ${this.maxOneLine} properties should be on multiple lines`))
+        } else if (node.properties.length > this.max_properties) {
+            warnings.push(this.warning(node.tokens, `object literals with more than ${this.max_properties} properties should be on multiple lines`))
         }
 
         for (const property of node.properties) {


### PR DESCRIPTION
- Change rule name from `then` to `must_have_then`
- Add rule enforcing formatting of object literals. 
  For single line literals default format is: `{ key: value, key: value }`
  For multi-line literals: 
    ```
    {
        key: value
        key: value
    }
    ```

Following rules are enforced for single line object literals:
- Colon should have 0 spaces on its left and one space on its right
- Opening brace should be followed by single space
- Closing brace should have single space before it
- Literal with more than 4 properties should use multi-line format
    ```
    { key: value }          👌
    {key: value }           ❌
    { key:value }           ❌
    { key: value}           ❌
    ```

Following rules are enforced for multi-line object literals:
- Colon should have 0 spaces on its left and one space on its right
- Opening brace should be followed by newline
- Closing brace should be on its own line
- No trailing commas
- One property per line
- All keys should be in quotes or all keys should be without quotes
    ```
    {
        key: value                        👌
    }

    { key: value                          ❌
    }

    {
    key: value }                          ❌

    {
        key: value, key: value.           ❌
    }

    {
        key: value,                       ❌
        key: value
    }
    ```

